### PR TITLE
Update useGetValidatorsEvents.ts

### DIFF
--- a/apps/core/src/hooks/useGetValidatorsEvents.ts
+++ b/apps/core/src/hooks/useGetValidatorsEvents.ts
@@ -9,7 +9,7 @@ type GetValidatorsEvent = {
 	order: 'ascending' | 'descending';
 };
 
-// NOTE: This copys the query limit from our Rust JSON RPC backend, this needs to be kept in sync!
+// NOTE: This copies the query limit from our Rust JSON RPC backend, this needs to be kept in sync!
 const QUERY_MAX_RESULT_LIMIT = 50;
 const VALIDATORS_EVENTS_QUERY = '0x3::validator_set::ValidatorEpochInfoEventV2';
 


### PR DESCRIPTION
Fixed a spelling error in the comment within useGetValidatorsEvents.ts:
- Changed "copys" to "copies" in the note about query limit