### PR TITLE
fix: bump builder to node:22 so pnpm@latest works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a Node.js image to build the app
-FROM node:20 AS builder
+FROM node:22 AS builder
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
## Problem

`Talus-Network/nexus-workbench`'s `build-explorer` step started failing in CI:

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
...
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
  at Module._load (node:internal/modules/cjs/loader:1031:13)
  ...
```

`corepack prepare pnpm@latest --activate` resolves to pnpm 11.1.1, which uses Node 22.13's `node:sqlite` built-in. Our builder is `FROM node:20`, so it blows up.

## Fix

Bump the builder stage from `node:20` to `node:22`. Node 22 is the current LTS; `package.json` engines is `>=20`, so this is in-range. Avoids the alternative of pinning pnpm to a 10.x version that'll rot.

## Test plan

- [ ] CI build of this Dockerfile succeeds (pnpm install + build)
- [ ] After merge: nexus-workbench `build-images.yml` run picks up the new HEAD and `build-explorer` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)