### PR TITLE
fix: whitelist esbuild via pnpm allowBuilds (follow-up to #5)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
   - 'apps/**'
+
+# pnpm >=10 blocks postinstall scripts by default. esbuild needs its
+# postinstall to download the native binary, so whitelist it.
+# (pnpm 11 renamed `onlyBuiltDependencies` → `allowBuilds`.)
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Problem

After #5 bumped the builder to `node:22`, the workbench `build-explorer` step still fails — but now on a *different* pnpm 11 default:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
  esbuild@0.18.20, esbuild@0.19.12, esbuild@0.20.2
Run "pnpm approve-builds" to pick which dependencies should be
allowed to run scripts.
```

pnpm 11 blocks every postinstall script by default. esbuild's postinstall is what downloads its native binary, so the build can't proceed without it.

## Fix

Whitelist esbuild via pnpm's `allowBuilds` setting in `pnpm-workspace.yaml`. pnpm 11 [renamed](https://pnpm.io/settings) `onlyBuiltDependencies` (list) → `allowBuilds` (map of name → bool), which is why an obvious-looking `onlyBuiltDependencies: [esbuild]` is silently ignored under pnpm 11.

```yaml
allowBuilds:
  esbuild: true
```

## Verification

Built the Dockerfile locally on this branch:
- `pnpm i` completes (esbuild postinstall runs)
- `pnpm run build` completes
- final nginx image lands

## Test plan

- [ ] After merge: nexus-workbench `build-images.yml` run for `build-explorer` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)